### PR TITLE
Custom batch size for InfoGAN 

### DIFF
--- a/InfoGAN/src/utils/data_utils.py
+++ b/InfoGAN/src/utils/data_utils.py
@@ -87,7 +87,7 @@ def get_disc_batch(X_real_batch, generator_model, batch_counter, batch_size, cat
         y_cont = sample_noise(noise_scale, batch_size, cont_dim)
         noise_input = sample_noise(noise_scale, batch_size, noise_dim)
         # Produce an output
-        X_disc = generator_model.predict([y_cat, y_cont, noise_input])
+        X_disc = generator_model.predict([y_cat, y_cont, noise_input],batch_size=batch_size)
         y_disc = np.zeros((X_disc.shape[0], 2), dtype=np.uint8)
         y_disc[:, 0] = 1
 
@@ -141,7 +141,7 @@ def plot_generated_batch(X_real, generator_model, batch_size, cat_dim, cont_dim,
     y_cont = sample_noise(noise_scale, batch_size, cont_dim)
     noise_input = sample_noise(noise_scale, batch_size, noise_dim)
     # Produce an output
-    X_gen = generator_model.predict([y_cat, y_cont, noise_input])
+    X_gen = generator_model.predict([y_cat, y_cont, noise_input],batch_size=batch_size)
 
     X_real = inverse_normalization(X_real)
     X_gen = inverse_normalization(X_gen)


### PR DESCRIPTION
For issue #19 
We need to pass batch size also when calling generator to predict an image. Following are the changes:

1. In data_utils, Function get_disc_batch  and plot_generated_batch call's predict function on generator model. As per Keras documentation(https://keras.io/models/sequential/) , we need to pass batch_size variable. Previously it didn't gave error because batch_size was 32 and predict function default batch_size is 32.