### PR TITLE
Update parmap API to remove DeprecationWarnings

### DIFF
--- a/Colorful/src/data/make_dataset.py
+++ b/Colorful/src/data/make_dataset.py
@@ -93,7 +93,7 @@ def build_HDF5(size=64):
             for chunk_idx in tqdm(arr_chunks):
 
                 list_img_path = list_img[chunk_idx].tolist()
-                output = parmap.map(format_image, list_img_path, size, parallel=True)
+                output = parmap.map(format_image, list_img_path, size, pm_parallel=True)
 
                 arr_img_color = np.vstack([o[0] for o in output if o[0].shape[0] > 0])
                 arr_img_lab = np.vstack([o[1] for o in output if o[0].shape[0] > 0])

--- a/DFI/src/data/make_dataset.py
+++ b/DFI/src/data/make_dataset.py
@@ -83,7 +83,7 @@ def build_HDF5(size):
         for chunk_idx in tqdm(arr_chunks):
 
             list_img_path = arr_img[chunk_idx].tolist()
-            output = parmap.map(format_image, list_img_path, size, parallel=True)
+            output = parmap.map(format_image, list_img_path, size, pm_parallel=True)
 
             arr_img_color = np.concatenate(output, axis=0)
 

--- a/GAN/src/data/make_dataset.py
+++ b/GAN/src/data/make_dataset.py
@@ -52,7 +52,7 @@ def build_HDF5(jpeg_dir, size=64):
             for chunk_idx in tqdm(arr_chunks):
 
                 list_img_path = list_img[chunk_idx].tolist()
-                output = parmap.map(format_image, list_img_path, size, parallel=True)
+                output = parmap.map(format_image, list_img_path, size, pm_parallel=True)
 
                 arr_img_color = np.concatenate(output, axis=0)
 

--- a/InfoGAN/src/data/make_dataset.py
+++ b/InfoGAN/src/data/make_dataset.py
@@ -52,7 +52,7 @@ def build_HDF5(jpeg_dir, size=64):
             for chunk_idx in tqdm(arr_chunks):
 
                 list_img_path = list_img[chunk_idx].tolist()
-                output = parmap.map(format_image, list_img_path, size, parallel=True)
+                output = parmap.map(format_image, list_img_path, size, pm_parallel=True)
 
                 arr_img_color = np.concatenate(output, axis=0)
 

--- a/WassersteinGAN/src/data/make_dataset.py
+++ b/WassersteinGAN/src/data/make_dataset.py
@@ -52,7 +52,7 @@ def build_HDF5(jpeg_dir, size=64):
             for chunk_idx in tqdm(arr_chunks):
 
                 list_img_path = list_img[chunk_idx].tolist()
-                output = parmap.map(format_image, list_img_path, size, parallel=True)
+                output = parmap.map(format_image, list_img_path, size, pm_parallel=True)
 
                 arr_img_color = np.concatenate(output, axis=0)
 

--- a/pix2pix/src/data/make_dataset.py
+++ b/pix2pix/src/data/make_dataset.py
@@ -76,7 +76,7 @@ def build_HDF5(jpeg_dir, nb_channels, size=256):
             for chunk_idx in tqdm(arr_chunks):
 
                 list_img_path = list_img[chunk_idx].tolist()
-                output = parmap.map(format_image, list_img_path, size, nb_channels, parallel=False)
+                output = parmap.map(format_image, list_img_path, size, nb_channels, pm_parallel=False)
 
                 arr_img_full = np.concatenate([o[0] for o in output], axis=0)
                 arr_img_sketch = np.concatenate([o[1] for o in output], axis=0)


### PR DESCRIPTION
Hi,

parmap 1.5.0 introduced support for passing keyword arguments to mapped functions. The drawback of this feature is that a consistent naming of parmap arguments is needed in order to prevent conflicts
between parmap arguments and user-defined arguments. The new parmap convention is to prefix all its arguments with "pm_" (for parmap) as documented http://parmap.readthedocs.io/en/latest/

This commit updates the DeepLearningImplementations parmap calls to use the new API, removing the deprecation warnings that appear with `parmap==1.5.1` (the parmap version used).

https://github.com/zeehio/parmap/blob/e0bc5969ab13562ec9ea2d8131f1cd9ecb8448a7/ChangeLog#L11

Feel free to merge if you see fit :+1:

Sergio *(parmap author)*