### PR TITLE
fix args pass in `transition` function

### DIFF
--- a/DenseNet/densenet.py
+++ b/DenseNet/densenet.py
@@ -173,7 +173,7 @@ def DenseNet(nb_classes, img_dim, depth, nb_dense_block, growth_rate,
                                   dropout_rate=dropout_rate,
                                   weight_decay=weight_decay)
         # add transition
-        x = transition(x, nb_filter, dropout_rate=dropout_rate,
+        x = transition(x, concat_axis, nb_filter, dropout_rate=dropout_rate,
                        weight_decay=weight_decay)
 
     # The last denseblock does not have a transition


### PR DESCRIPTION
As reported is [issue #69](https://github.com/tdeboissiere/DeepLearningImplementations/issues/69). Here is a parameter `concat_axis` missed to pass to `transition` function.