### PR TITLE
Line 38: Deleted redundant  argument <True> after <--do_plot>.

### DIFF
--- a/pix2pix/src/data/README.md
+++ b/pix2pix/src/data/README.md
@@ -35,4 +35,4 @@ optional arguments:
 
 **Example:**
 
-`python make_dataset.py /home/user/GitHub/pix2pix/datasets/facades 3 --img_size 256 --do_plot True`
+`python make_dataset.py /home/user/GitHub/pix2pix/datasets/facades 3 --img_size 256 --do_plot`


### PR DESCRIPTION
"True" is redundant for "--do_plot". The function does not run with this but it does without.